### PR TITLE
[Bug #147680875] Fix heroku delete bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 sudo: required
 dist: trusty
 language: node_js
-deploy:
-  exclude: "/client/components/elements/LoginTabs.jsx"
 
 node_js:
   - 6

--- a/client/actions/ajaxStatusActions.js
+++ b/client/actions/ajaxStatusActions.js
@@ -1,7 +1,7 @@
 import * as actionTypes from './actionTypes';
 
 /**
- * Action creator that start is called when ajax call begins
+ * Action creator that's called when ajax call begins
  * @returns {object} action
  */
 export function beginAjaxCall() {

--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -1,8 +1,8 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import loader from '../img/loader.gif';
-import Nav from '../components/layouts/Nav.jsx';
-import Footer from '../components/layouts/Footer.jsx';
+import Nav from '../components/layouts/Nav';
+import Footer from '../components/layouts/Footer';
 
 /**
  * Top level component

--- a/client/components/elements/LoginTabs.jsx
+++ b/client/components/elements/LoginTabs.jsx
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
-import SignupForm from '../forms/SignupForm.jsx';
-import SigninForm from '../forms/SigninForm.jsx';
+import SignupForm from '../forms/SignupForm';
+import SigninForm from '../forms/SigninForm';
 
 function LoginTabs({ onSigninSubmit, signinDetails, signinErrors,
   handleSigninChange, pathname, onSubmit, handleChange, signupErrors,

--- a/client/components/forms/Searchbar.jsx
+++ b/client/components/forms/Searchbar.jsx
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
-import TextInput from '../forms/TextInput.jsx';
+import TextInput from '../forms/TextInput';
 import { searchUsers, searchDocuments } from '../../actions/searchActions';
 
 /**

--- a/client/components/forms/SigninForm.jsx
+++ b/client/components/forms/SigninForm.jsx
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 import FlatButton from 'material-ui/FlatButton';
-import TextInput from '../forms/TextInput.jsx';
+import TextInput from '../forms/TextInput';
 
 /**
  * Renders the sign in form

--- a/client/components/forms/SignupForm.jsx
+++ b/client/components/forms/SignupForm.jsx
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
 import FlatButton from 'material-ui/FlatButton';
-import TextInput from '../forms/TextInput.jsx';
-import SelectInput from '../forms/SelectInput.jsx';
+import TextInput from '../forms/TextInput';
+import SelectInput from '../forms/SelectInput';
 
 /**
  * Renders the sign up form or edit profile form

--- a/client/components/layouts/ProfileSidebar.jsx
+++ b/client/components/layouts/ProfileSidebar.jsx
@@ -42,7 +42,7 @@ function ProfileSidebar({ user, access, deleteUser }) {
           />
         </Link>
         {access.user.id === user.id
-        && <a href="#!" onClick={deleteUser}>
+        && <a className="delete" onClick={deleteUser}>
           <RaisedButton
             title="This will delete your account"
             label="DELETE"

--- a/client/components/layouts/Sidebar.jsx
+++ b/client/components/layouts/Sidebar.jsx
@@ -1,9 +1,9 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import toastr from 'toastr';
-import AdminSidebar from './AdminSidebar.jsx';
-import ProfileSidebar from './ProfileSidebar.jsx';
-import DocumentSidebar from './DocumentSidebar.jsx';
+import AdminSidebar from './AdminSidebar';
+import ProfileSidebar from './ProfileSidebar';
+import DocumentSidebar from './DocumentSidebar';
 import handleError from '../../utils/errorHandler';
 import { deleteUser, logout } from '../../actions/userActions';
 
@@ -39,22 +39,22 @@ export class Sidebar extends React.Component {
    * @memberOf Sidebar
    */
   deleteUser() {
-    // swal({
-    //   title: 'Are you sure?',
-    //   text: 'This user will be permanently deleted!',
-    //   type: 'warning',
-    //   showCancelButton: true,
-    //   confirmButtonColor: '#DD6B55',
-    //   confirmButtonText: 'Yes, delete it!',
-    //   cancelButtonText: 'No, cancel this!'
-    // })
-    // .then((isConfirm) => {
-    //   if (isConfirm) {
-    this.delete();
-    //   }
-    // })
-    // .catch((err) =>
-    //   swal('Cancelled', 'The user is safe :)'));
+    swal({
+      title: 'Are you sure?',
+      text: 'This user will be permanently deleted!',
+      type: 'warning',
+      showCancelButton: true,
+      confirmButtonColor: '#DD6B55',
+      confirmButtonText: 'Yes, delete it!',
+      cancelButtonText: 'No, cancel this!'
+    })
+    .then((isConfirm) => {
+      if (isConfirm) {
+        this.delete();
+      }
+    })
+    .catch((err) =>
+      swal('Cancelled', 'The user is safe :)'));
   }
 
   delete() {
@@ -63,7 +63,7 @@ export class Sidebar extends React.Component {
         this.props.logout();
         this.context.router.push('/');
         location.reload();
-        // this.redirect();
+        this.redirect();
       });
   }
 
@@ -72,7 +72,7 @@ export class Sidebar extends React.Component {
    * @memberOf Sidebar
    */
   redirect = () => {
-    // swal('Deleted!', 'Your Account has been deleted.', 'success');
+    swal('Deleted!', 'Your Account has been deleted.', 'success');
   }
 
   /**

--- a/client/components/layouts/Sidebar.jsx
+++ b/client/components/layouts/Sidebar.jsx
@@ -39,22 +39,22 @@ export class Sidebar extends React.Component {
    * @memberOf Sidebar
    */
   deleteUser() {
-    swal({
-      title: 'Are you sure?',
-      text: 'This user will be permanently deleted!',
-      type: 'warning',
-      showCancelButton: true,
-      confirmButtonColor: '#DD6B55',
-      confirmButtonText: 'Yes, delete it!',
-      cancelButtonText: 'No, cancel this!'
-    })
-    .then((isConfirm) => {
-      if (isConfirm) {
-        this.delete();
-      }
-    })
-    .catch((err) =>
-      swal('Cancelled', 'The user is safe :)'));
+    // swal({
+    //   title: 'Are you sure?',
+    //   text: 'This user will be permanently deleted!',
+    //   type: 'warning',
+    //   showCancelButton: true,
+    //   confirmButtonColor: '#DD6B55',
+    //   confirmButtonText: 'Yes, delete it!',
+    //   cancelButtonText: 'No, cancel this!'
+    // })
+    // .then((isConfirm) => {
+    //   if (isConfirm) {
+    this.delete();
+    //   }
+    // })
+    // .catch((err) =>
+    //   swal('Cancelled', 'The user is safe :)'));
   }
 
   delete() {
@@ -63,7 +63,7 @@ export class Sidebar extends React.Component {
         this.props.logout();
         this.context.router.push('/');
         location.reload();
-        this.redirect();
+        // this.redirect();
       });
   }
 
@@ -72,7 +72,7 @@ export class Sidebar extends React.Component {
    * @memberOf Sidebar
    */
   redirect = () => {
-    swal('Deleted!', 'Your Account has been deleted.', 'success');
+    // swal('Deleted!', 'Your Account has been deleted.', 'success');
   }
 
   /**

--- a/client/components/pages/EditDocumentPage.jsx
+++ b/client/components/pages/EditDocumentPage.jsx
@@ -5,13 +5,14 @@ import { Link } from 'react-router';
 import toastr from 'toastr';
 import TinyMCE from 'react-tinymce';
 import FlatButton from 'material-ui/FlatButton';
-import * as validate from '../../utils/validate';
-import SelectInput from '../forms/SelectInput.jsx';
-import TextInput from '../forms/TextInput.jsx';
-import Sidebar from '../layouts/Sidebar.jsx';
 import * as documentActions from '../../actions/documentActions';
 import handleError from '../../utils/errorHandler';
 import getDocument from '../../utils/getDocument';
+import * as validate from '../../utils/validate';
+import SelectInput from '../forms/SelectInput';
+import TextInput from '../forms/TextInput';
+import Sidebar from '../layouts/Sidebar';
+
 
 /**
  * Control the edit document page
@@ -32,18 +33,11 @@ export class EditDocumentPage extends React.Component {
   }
 
   /**
-   * Calls actions to get the document by id
-   * @memberOf ViewDocumentPage
-   */
-  componentWillMount() {
-    this.props.actions.getDocument(this.props.params.id);
-  }
-
-  /**
    * Initialises the select box
    * @memberOf EditDocumentPage
    */
   componentDidMount() {
+    this.props.actions.getDocument(this.props.params.id);
     $('select').material_select();
     $('#select-box').on('change', this.handleChange);
   }

--- a/client/components/pages/EditProfilePage.jsx
+++ b/client/components/pages/EditProfilePage.jsx
@@ -2,11 +2,11 @@ import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import toastr from 'toastr';
-import SignupForm from '../forms/SignupForm.jsx';
+import SignupForm from '../forms/SignupForm';
 import handleError from '../../utils/errorHandler';
 import * as validate from '../../utils/validate';
 import { updateUser } from '../../actions/userActions';
-import Sidebar from '../layouts/Sidebar.jsx';
+import Sidebar from '../layouts/Sidebar';
 
 /**
  * Controls the edit profile page

--- a/client/components/pages/HomePage.jsx
+++ b/client/components/pages/HomePage.jsx
@@ -1,11 +1,11 @@
 import React, { PropTypes } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import Nav from '../layouts/Nav.jsx';
-import Sidebar from '../layouts/Sidebar.jsx';
-import Document from '../elements/Document.jsx';
-import Searchbar from '../forms/Searchbar.jsx';
-import Pagination from '../elements/Pagination.jsx';
+import Nav from '../layouts/Nav';
+import Sidebar from '../layouts/Sidebar';
+import Document from '../elements/Document';
+import Searchbar from '../forms/Searchbar';
+import Pagination from '../elements/Pagination';
 import * as userActions from '../../actions/userActions';
 import { nextPage, prevPage } from '../../utils/paginate';
 import * as searchActions from '../../actions/searchActions';
@@ -27,10 +27,10 @@ export class HomePage extends React.Component {
   }
 
   /**
-   * Calls function before component mounts
+   * Calls function after component mounts
    * @memberOf HomePage
    */
-  componentWillMount() {
+  componentDidMount() {
     this.props.actions.getDocuments();
   }
 

--- a/client/components/pages/LandingPage.jsx
+++ b/client/components/pages/LandingPage.jsx
@@ -2,7 +2,7 @@ import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import toastr from 'toastr';
-import LoginTabs from '../elements/LoginTabs.jsx';
+import LoginTabs from '../elements/LoginTabs';
 import handleError from '../../utils/errorHandler';
 import * as validate from '../../utils/validate';
 import { signup, signin } from '../../actions/userActions';

--- a/client/components/pages/ManageRolesPage.jsx
+++ b/client/components/pages/ManageRolesPage.jsx
@@ -152,8 +152,10 @@ export class ManageRolesPage extends React.Component {
         });
       }
     })
-    .catch((err) =>
-      swal('Cancelled', 'The role is not deleted :)'));
+    .catch((err) => {
+      console.log('Error', err);
+      swal('Cancelled', 'The role is not deleted :)');
+    });
   }
 
   /**

--- a/client/components/pages/ManageRolesPage.jsx
+++ b/client/components/pages/ManageRolesPage.jsx
@@ -135,27 +135,27 @@ export class ManageRolesPage extends React.Component {
    * @memberOf ManageRolesPage
    */
   deleteRole(roleId) {
-    swal({
-      title: 'Are you sure?',
-      text: 'This role will be permanently deleted!',
-      type: 'warning',
-      showCancelButton: true,
-      confirmButtonColor: '#DD6B55',
-      confirmButtonText: 'Yes, delete it!',
-      cancelButtonText: 'No, cancel this!'
-    })
-    .then((isConfirm) => {
-      if (isConfirm) {
-        this.props.actions.deleteRole(roleId)
-        .then(() => {
-          swal('Deleted!', 'The role has been deleted.', 'success');
-        });
-      }
-    })
-    .catch((err) => {
-      console.log('Error', err);
-      swal('Cancelled', 'The role is not deleted :)');
-    });
+    // swal({
+    //   title: 'Are you sure?',
+    //   text: 'This role will be permanently deleted!',
+    //   type: 'warning',
+    //   showCancelButton: true,
+    //   confirmButtonColor: '#DD6B55',
+    //   confirmButtonText: 'Yes, delete it!',
+    //   cancelButtonText: 'No, cancel this!'
+    // })
+    // .then((isConfirm) => {
+    //   if (isConfirm) {
+    this.props.actions.deleteRole(roleId);
+    //     .then(() => {
+    //       swal('Deleted!', 'The role has been deleted.', 'success');
+    //     });
+    //   }
+    // })
+    // .catch((err) => {
+    //   console.log('Error', err);
+    //   swal('Cancelled', 'The role is not deleted :)');
+    // });
   }
 
   /**

--- a/client/components/pages/ManageRolesPage.jsx
+++ b/client/components/pages/ManageRolesPage.jsx
@@ -1,18 +1,18 @@
 import React, { PropTypes } from 'react';
-import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
 import { Link } from 'react-router';
 import toastr from 'toastr';
+import FlatButton from 'material-ui/FlatButton';
 import Divider from 'material-ui/Divider';
 import { Card } from 'material-ui/Card';
-import FlatButton from 'material-ui/FlatButton';
 import { Table, TableBody, TableHeader, TableHeaderColumn,
   TableRow, TableRowColumn } from 'material-ui/Table';
-import Nav from '../layouts/Nav.jsx';
-import Sidebar from '../layouts/Sidebar.jsx';
+import Nav from '../layouts/Nav';
+import TextInput from '../forms/TextInput';
+import Sidebar from '../layouts/Sidebar';
 import * as roleActions from '../../actions/roleActions';
 import insertRole from '../../utils/insertRole';
-import TextInput from '../forms/TextInput.jsx';
 import handleError from '../../utils/errorHandler';
 
 /**
@@ -35,19 +35,14 @@ export class ManageRolesPage extends React.Component {
     this.onEditSubmit = this.onEditSubmit.bind(this);
     this.onSubmit = this.onSubmit.bind(this);
   }
-  /**
-   * Calls action before component mounts
-   * @memberOf ManageRolesPage
-   */
-  componentWillMount() {
-    this.props.actions.getRoles();
-  }
 
   /**
+   * Calls action after component mounts
    * Initializes modal
    * @memberOf ManageRolesPage
    */
   componentDidMount = () => {
+    this.props.actions.getRoles();
     $('.modal').modal();
   }
 
@@ -135,27 +130,26 @@ export class ManageRolesPage extends React.Component {
    * @memberOf ManageRolesPage
    */
   deleteRole(roleId) {
-    // swal({
-    //   title: 'Are you sure?',
-    //   text: 'This role will be permanently deleted!',
-    //   type: 'warning',
-    //   showCancelButton: true,
-    //   confirmButtonColor: '#DD6B55',
-    //   confirmButtonText: 'Yes, delete it!',
-    //   cancelButtonText: 'No, cancel this!'
-    // })
-    // .then((isConfirm) => {
-    //   if (isConfirm) {
-    this.props.actions.deleteRole(roleId);
-    //     .then(() => {
-    //       swal('Deleted!', 'The role has been deleted.', 'success');
-    //     });
-    //   }
-    // })
-    // .catch((err) => {
-    //   console.log('Error', err);
-    //   swal('Cancelled', 'The role is not deleted :)');
-    // });
+    swal({
+      title: 'Are you sure?',
+      text: 'This role will be permanently deleted!',
+      type: 'warning',
+      showCancelButton: true,
+      confirmButtonColor: '#DD6B55',
+      confirmButtonText: 'Yes, delete it!',
+      cancelButtonText: 'No, cancel this!'
+    })
+    .then((isConfirm) => {
+      if (isConfirm) {
+        this.props.actions.deleteRole(roleId)
+        .then(() => {
+          swal('Deleted!', 'The role has been deleted.', 'success');
+        });
+      }
+    })
+    .catch((err) => {
+      swal('Cancelled', 'The role is not deleted :)');
+    });
   }
 
   /**

--- a/client/components/pages/ManageRolesPage.jsx
+++ b/client/components/pages/ManageRolesPage.jsx
@@ -34,6 +34,7 @@ export class ManageRolesPage extends React.Component {
     this.handleChange = this.handleChange.bind(this);
     this.onEditSubmit = this.onEditSubmit.bind(this);
     this.onSubmit = this.onSubmit.bind(this);
+    this.deleteRole = this.deleteRole.bind(this);
   }
 
   /**
@@ -166,7 +167,7 @@ export class ManageRolesPage extends React.Component {
             <i className="material-icons">edit</i>
           </a>
           {role.id > 3
-          && <a href="#!" onClick={() => { this.deleteRole(role.id); }}>
+          && <a className="delete" onClick={() => this.deleteRole(role.id)}>
               <i className="material-icons">delete_forever</i>
             </a>}
         </TableRowColumn>

--- a/client/components/pages/ManageUsersPage.jsx
+++ b/client/components/pages/ManageUsersPage.jsx
@@ -7,10 +7,10 @@ import { Card } from 'material-ui/Card';
 import {
   Table, TableBody, TableHeader, TableHeaderColumn,
   TableRow, TableRowColumn } from 'material-ui/Table';
-import Nav from '../layouts/Nav.jsx';
-import Sidebar from '../layouts/Sidebar.jsx';
-import Searchbar from '../forms/Searchbar.jsx';
-import Pagination from '../elements/Pagination.jsx';
+import Nav from '../layouts/Nav';
+import Sidebar from '../layouts/Sidebar';
+import Searchbar from '../forms/Searchbar';
+import Pagination from '../elements/Pagination';
 import { nextPage, prevPage } from '../../utils/paginate';
 import * as userActions from '../../actions/userActions';
 import * as searchActions from '../../actions/searchActions';
@@ -32,10 +32,10 @@ export class ManageUsersPage extends React.Component {
   }
 
   /**
-   * Call to get users before component mounts
+   * Call to get users after component mounts
    * @memberOf ManageUsersPage
    */
-  componentWillMount() {
+  componentDidMount() {
     this.props.actions.getUsers();
   }
 

--- a/client/components/pages/NewDocumentPage.jsx
+++ b/client/components/pages/NewDocumentPage.jsx
@@ -8,9 +8,9 @@ import FlatButton from 'material-ui/FlatButton';
 import { createDocument } from '../../actions/documentActions';
 import * as validate from '../../utils/validate';
 import handleError from '../../utils/errorHandler';
-import SelectInput from '../forms/SelectInput.jsx';
-import TextInput from '../forms/TextInput.jsx';
-import Sidebar from '../layouts/Sidebar.jsx';
+import SelectInput from '../forms/SelectInput';
+import TextInput from '../forms/TextInput';
+import Sidebar from '../layouts/Sidebar';
 
 /**
  * The Create New Document Page

--- a/client/components/pages/ProfilePage.jsx
+++ b/client/components/pages/ProfilePage.jsx
@@ -1,11 +1,11 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import Nav from '../layouts/Nav.jsx';
-import Sidebar from '../layouts/Sidebar.jsx';
-import Searchbar from '../forms/Searchbar.jsx';
-import Document from '../elements/Document.jsx';
-import Pagination from '../elements/Pagination.jsx';
+import Nav from '../layouts/Nav';
+import Sidebar from '../layouts/Sidebar';
+import Searchbar from '../forms/Searchbar';
+import Document from '../elements/Document';
+import Pagination from '../elements/Pagination';
 import * as userActions from '../../actions/userActions';
 import { nextPage, prevPage } from '../../utils/paginate';
 import * as documentActions from '../../actions/documentActions';
@@ -32,7 +32,7 @@ export class ProfilePage extends React.Component {
    * Calls actions to get user information and documents
    * @memberOf ProfilePage
    */
-  componentWillMount() {
+  componentDidMount() {
     this.props.actions.getUser(this.props.params.id);
     this.props.actions.getUserDocuments(this.props.params.id);
   }

--- a/client/components/pages/UserDocumentsPage.jsx
+++ b/client/components/pages/UserDocumentsPage.jsx
@@ -1,10 +1,10 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
-import Nav from '../layouts/Nav.jsx';
-import Sidebar from '../layouts/Sidebar.jsx';
-import Searchbar from '../forms/Searchbar.jsx';
-import Document from '../elements/Document.jsx';
-import Pagination from '../elements/Pagination.jsx';
+import Nav from '../layouts/Nav';
+import Sidebar from '../layouts/Sidebar';
+import Searchbar from '../forms/Searchbar';
+import Document from '../elements/Document';
+import Pagination from '../elements/Pagination';
 import { nextPage, prevPage } from '../../utils/paginate';
 import { getUserDocuments } from '../../actions/documentActions';
 
@@ -25,10 +25,10 @@ export class UserDocumentsPage extends React.Component {
   }
 
   /**
-   * Calls actions for the user's documents before component mounts
+   * Calls actions for the user's documents after component mounts
    * @memberOf UserDocumentsPage
    */
-  componentWillMount() {
+  componentDidMount() {
     this.props.getUserDocuments(this.props.params.id);
   }
 

--- a/client/components/pages/ViewDocumentPage.jsx
+++ b/client/components/pages/ViewDocumentPage.jsx
@@ -92,7 +92,7 @@ export class ViewDocumentPage extends React.Component {
               >
                 <i className="material-icons">mode_edit</i>
               </Link>
-              <a href="#!" onClick={this.deleteDocument}
+              <a className="delete" onClick={this.deleteDocument}
                 className="btn-floating waves-effect waves-light red btn-delete"
                 title="Delete document"
               >

--- a/client/components/pages/ViewDocumentPage.jsx
+++ b/client/components/pages/ViewDocumentPage.jsx
@@ -31,22 +31,22 @@ export class ViewDocumentPage extends React.Component {
    * @memberOf ViewDocumentPage
    */
   deleteDocument = () => {
-    swal({
-      title: 'Are you sure?',
-      text: 'You will not be able to recover this document!',
-      type: 'warning',
-      showCancelButton: true,
-      confirmButtonColor: '#DD6B55',
-      confirmButtonText: 'Yes, delete it!',
-      cancelButtonText: 'No, cancel this!'
-    })
-    .then((isConfirm) => {
-      if (isConfirm) {
-        this.delete();
-      }
-    })
-    .catch((er) =>
-      swal('Cancelled', 'The document is safe :)', 'error'));
+    // swal({
+    //   title: 'Are you sure?',
+    //   text: 'You will not be able to recover this document!',
+    //   type: 'warning',
+    //   showCancelButton: true,
+    //   confirmButtonColor: '#DD6B55',
+    //   confirmButtonText: 'Yes, delete it!',
+    //   cancelButtonText: 'No, cancel this!'
+    // })
+    // .then((isConfirm) => {
+    //   if (isConfirm) {
+    this.delete();
+    //   }
+    // })
+    // .catch((er) =>
+    //   swal('Cancelled', 'The document is safe :)', 'error'));
   }
 
   /**
@@ -63,7 +63,7 @@ export class ViewDocumentPage extends React.Component {
    * @memberOf ViewDocumentPage
    */
   redirect() {
-    swal('Deleted!', 'This document has been deleted.', 'success');
+    // swal('Deleted!', 'This document has been deleted.', 'success');
     this.context.router.push('/home');
   }
 

--- a/client/components/pages/ViewDocumentPage.jsx
+++ b/client/components/pages/ViewDocumentPage.jsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router';
 import toastr from 'toastr';
 import Divider from 'material-ui/Divider';
 import handleError from '../../utils/errorHandler';
-import Sidebar from '../layouts/Sidebar.jsx';
+import Sidebar from '../layouts/Sidebar';
 import { getDocument, deleteDocument } from '../../actions/documentActions';
 
 /**
@@ -22,7 +22,7 @@ export class ViewDocumentPage extends React.Component {
    * Calls actions to get the document by id
    * @memberOf ViewDocumentPage
    */
-  componentWillMount() {
+  componentDidMount() {
     this.props.getDocument(this.props.params.id);
   }
 
@@ -31,22 +31,22 @@ export class ViewDocumentPage extends React.Component {
    * @memberOf ViewDocumentPage
    */
   deleteDocument = () => {
-    // swal({
-    //   title: 'Are you sure?',
-    //   text: 'You will not be able to recover this document!',
-    //   type: 'warning',
-    //   showCancelButton: true,
-    //   confirmButtonColor: '#DD6B55',
-    //   confirmButtonText: 'Yes, delete it!',
-    //   cancelButtonText: 'No, cancel this!'
-    // })
-    // .then((isConfirm) => {
-    //   if (isConfirm) {
-    this.delete();
-    //   }
-    // })
-    // .catch((er) =>
-    //   swal('Cancelled', 'The document is safe :)', 'error'));
+    swal({
+      title: 'Are you sure?',
+      text: 'You will not be able to recover this document!',
+      type: 'warning',
+      showCancelButton: true,
+      confirmButtonColor: '#DD6B55',
+      confirmButtonText: 'Yes, delete it!',
+      cancelButtonText: 'No, cancel this!'
+    })
+    .then((isConfirm) => {
+      if (isConfirm) {
+        this.delete();
+      }
+    })
+    .catch((er) =>
+      swal('Cancelled', 'The document is safe :)', 'error'));
   }
 
   /**
@@ -63,7 +63,7 @@ export class ViewDocumentPage extends React.Component {
    * @memberOf ViewDocumentPage
    */
   redirect() {
-    // swal('Deleted!', 'This document has been deleted.', 'success');
+    swal('Deleted!', 'This document has been deleted.', 'success');
     this.context.router.push('/home');
   }
 

--- a/client/scss/style.scss
+++ b/client/scss/style.scss
@@ -28,6 +28,10 @@ body {
   cursor: text;
 }
 
+.delete {
+  cursor: pointer;
+}
+
 .landing-page {
   min-height: 100vh;
   .landing-content {

--- a/client/tests/components/elements/Document.spec.js
+++ b/client/tests/components/elements/Document.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import expect from 'expect';
 import { shallow } from 'enzyme';
-import Document from '../../../components/elements/Document.jsx';
+import Document from '../../../components/elements/Document';
 
 function setup() {
   const props = {

--- a/client/tests/components/elements/LoginTabs.spec.js
+++ b/client/tests/components/elements/LoginTabs.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import expect from 'expect';
 import { shallow } from 'enzyme';
-import LoginTabs from '../../../components/elements/LoginTabs.jsx';
+import LoginTabs from '../../../components/elements/LoginTabs';
 
 function setup() {
   const props = {

--- a/client/tests/components/elements/Pagination.spec.js
+++ b/client/tests/components/elements/Pagination.spec.js
@@ -3,7 +3,7 @@ import expect from 'expect';
 import sinon from 'sinon';
 import { shallow } from 'enzyme';
 import enzymify from 'expect-enzyme';
-import Pagination from '../../../components/elements/Pagination.jsx';
+import Pagination from '../../../components/elements/Pagination';
 
 expect.extend(enzymify());
 const nextPage = sinon.spy(() => Promise.resolve());

--- a/client/tests/components/forms/Searchbar.spec.js
+++ b/client/tests/components/forms/Searchbar.spec.js
@@ -2,7 +2,7 @@ import expect from 'expect';
 import sinon from 'sinon';
 import React from 'react';
 import { mount } from 'enzyme';
-import { Searchbar } from '../../../components/forms/Searchbar.jsx';
+import { Searchbar } from '../../../components/forms/Searchbar';
 
 const spyHandleChange = sinon.spy(Searchbar.prototype, 'handleChange');
 const spySearch = sinon.spy(Searchbar.prototype, 'submitSearch');

--- a/client/tests/components/forms/SelectInput.spec.js
+++ b/client/tests/components/forms/SelectInput.spec.js
@@ -1,7 +1,7 @@
 import expect from 'expect';
 import React from 'react';
 import { shallow } from 'enzyme';
-import SelectInput from '../../../components/forms/SelectInput.jsx';
+import SelectInput from '../../../components/forms/SelectInput';
 
 function setup(id, error = '', pathname) {
   const props = {

--- a/client/tests/components/forms/Signin.spec.js
+++ b/client/tests/components/forms/Signin.spec.js
@@ -1,7 +1,7 @@
 import expect from 'expect';
 import React from 'react';
 import { shallow } from 'enzyme';
-import SigninForm from '../../../components/forms/SigninForm.jsx';
+import SigninForm from '../../../components/forms/SigninForm';
 
 function setup() {
   const props = {

--- a/client/tests/components/forms/Signup.spec.js
+++ b/client/tests/components/forms/Signup.spec.js
@@ -1,7 +1,7 @@
 import expect from 'expect';
 import React from 'react';
 import { shallow } from 'enzyme';
-import SignupForm from '../../../components/forms/SignupForm.jsx';
+import SignupForm from '../../../components/forms/SignupForm';
 
 function setup(pathname) {
   const props = {

--- a/client/tests/components/forms/TextInput.spec.js
+++ b/client/tests/components/forms/TextInput.spec.js
@@ -1,7 +1,7 @@
 import expect from 'expect';
 import React from 'react';
 import { shallow } from 'enzyme';
-import TextInput from '../../../components/forms/TextInput.jsx';
+import TextInput from '../../../components/forms/TextInput';
 
 function setup(errorText, value = 'ignatius@gmail.com') {
   const props = {

--- a/client/tests/components/layouts/AdminSidebar.spec.js
+++ b/client/tests/components/layouts/AdminSidebar.spec.js
@@ -2,7 +2,7 @@ import React from 'react';
 import expect from 'expect';
 import { shallow } from 'enzyme';
 import enzymify from 'expect-enzyme';
-import AdminSidebar from '../../../components/layouts/AdminSidebar.jsx';
+import AdminSidebar from '../../../components/layouts/AdminSidebar';
 
 expect.extend(enzymify());
 

--- a/client/tests/components/layouts/DocumentSidebar.spec.js
+++ b/client/tests/components/layouts/DocumentSidebar.spec.js
@@ -2,7 +2,7 @@ import React from 'react';
 import expect from 'expect';
 import { shallow } from 'enzyme';
 import enzymify from 'expect-enzyme';
-import DocumentSidebar from '../../../components/layouts/DocumentSidebar.jsx';
+import DocumentSidebar from '../../../components/layouts/DocumentSidebar';
 
 expect.extend(enzymify());
 

--- a/client/tests/components/layouts/Footer.spec.js
+++ b/client/tests/components/layouts/Footer.spec.js
@@ -2,7 +2,7 @@ import React from 'react';
 import expect from 'expect';
 import { shallow } from 'enzyme';
 import enzymify from 'expect-enzyme';
-import Footer from '../../../components/layouts/Footer.jsx';
+import Footer from '../../../components/layouts/Footer';
 
 expect.extend(enzymify());
 

--- a/client/tests/components/layouts/Nav.spec.js
+++ b/client/tests/components/layouts/Nav.spec.js
@@ -2,7 +2,7 @@ import React from 'react';
 import expect from 'expect';
 import sinon from 'sinon';
 import { shallow, mount } from 'enzyme';
-import { Nav } from '../../../components/layouts/Nav.jsx';
+import { Nav } from '../../../components/layouts/Nav';
 
 const logout = sinon.spy(() => Promise.resolve());
 

--- a/client/tests/components/layouts/ProfileSidebar.spec.js
+++ b/client/tests/components/layouts/ProfileSidebar.spec.js
@@ -2,7 +2,7 @@ import React from 'react';
 import expect from 'expect';
 import sinon from 'sinon';
 import { shallow } from 'enzyme';
-import ProfileSidebar from '../../../components/layouts/ProfileSidebar.jsx';
+import ProfileSidebar from '../../../components/layouts/ProfileSidebar';
 
 const deleteUser = sinon.spy(() => Promise.resolve());
 

--- a/client/tests/components/layouts/Sidebar.spec.js
+++ b/client/tests/components/layouts/Sidebar.spec.js
@@ -2,7 +2,7 @@ import expect from 'expect';
 import sinon from 'sinon';
 import React from 'react';
 import { shallow, mount } from 'enzyme';
-import { Sidebar } from '../../../components/layouts/Sidebar.jsx';
+import { Sidebar } from '../../../components/layouts/Sidebar';
 
 const logout = sinon.spy(() => Promise.resolve());
 const deleteUser = sinon.spy(() => Promise.resolve());

--- a/client/tests/components/pages/EditDocumentPage.spec.js
+++ b/client/tests/components/pages/EditDocumentPage.spec.js
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 import { EditDocumentPage } from
-'../../../components/pages/EditDocumentPage.jsx';
+'../../../components/pages/EditDocumentPage';
 
 const getDocument = sinon.spy(() => Promise.resolve());
 const updateDocument = sinon.spy(() => Promise.resolve());

--- a/client/tests/components/pages/EditProfilePage.spec.js
+++ b/client/tests/components/pages/EditProfilePage.spec.js
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 import { EditProfilePage } from
-'../../../components/pages/EditProfilePage.jsx';
+'../../../components/pages/EditProfilePage';
 
 const updateUser = sinon.spy(() => Promise.resolve());
 const spyHandleChange = sinon.spy(EditProfilePage.prototype, 'handleChange');

--- a/client/tests/components/pages/HomePage.spec.js
+++ b/client/tests/components/pages/HomePage.spec.js
@@ -4,11 +4,10 @@ import React from 'react';
 import { shallow, mount } from 'enzyme';
 import { nextPage, prevPage } from '../../../utils/paginate';
 import { HomePage } from
-'../../../components/pages/HomePage.jsx';
+'../../../components/pages/HomePage';
 
 const getDocuments = sinon.spy(() => Promise.resolve());
 const searchDocuments = sinon.spy(() => Promise.resolve());
-const componentMount = sinon.spy(HomePage.prototype, 'componentWillMount');
 const nextPageSpy = sinon.spy(nextPage);
 const prevPageSpy = sinon.spy(prevPage);
 

--- a/client/tests/components/pages/LandingPage.spec.js
+++ b/client/tests/components/pages/LandingPage.spec.js
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 import { LandingPage } from
-'../../../components/pages/LandingPage.jsx';
+'../../../components/pages/LandingPage';
 
 const signup = sinon.spy(() => Promise.resolve());
 const signin = sinon.spy(() => Promise.resolve());

--- a/client/tests/components/pages/ManageRolesPage.spec.js
+++ b/client/tests/components/pages/ManageRolesPage.spec.js
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 import { ManageRolesPage } from
-'../../../components/pages/ManageRolesPage.jsx';
+'../../../components/pages/ManageRolesPage';
 
 const getRoles = sinon.spy(() => Promise.resolve());
 const createRole = sinon.spy(() => Promise.resolve());

--- a/client/tests/components/pages/ManageUsersPage.spec.js
+++ b/client/tests/components/pages/ManageUsersPage.spec.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { shallow, mount } from 'enzyme';
 import { nextPage, prevPage } from '../../../utils/paginate';
 import { ManageUsersPage } from
-'../../../components/pages/ManageUsersPage.jsx';
+'../../../components/pages/ManageUsersPage';
 
 const getUsers = sinon.spy(() => Promise.resolve());
 const searchUsers = sinon.spy(() => Promise.resolve());

--- a/client/tests/components/pages/NewDocumentPage.spec.js
+++ b/client/tests/components/pages/NewDocumentPage.spec.js
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 import { NewDocumentPage } from
-'../../../components/pages/NewDocumentPage.jsx';
+'../../../components/pages/NewDocumentPage';
 
 const createDocument = sinon.spy(() => Promise.resolve());
 const spyHandleChange = sinon.spy(NewDocumentPage.prototype, 'handleChange');

--- a/client/tests/components/pages/ProfilePage.spec.js
+++ b/client/tests/components/pages/ProfilePage.spec.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { shallow, mount } from 'enzyme';
 import { nextPage, prevPage } from '../../../utils/paginate';
 import { ProfilePage } from
-'../../../components/pages/ProfilePage.jsx';
+'../../../components/pages/ProfilePage';
 
 const getUser = sinon.spy(() => Promise.resolve());
 const getUserDocuments = sinon.spy(() => Promise.resolve());

--- a/client/tests/components/pages/UserDocumentsPage.spec.js
+++ b/client/tests/components/pages/UserDocumentsPage.spec.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { shallow, mount } from 'enzyme';
 import { nextPage, prevPage } from '../../../utils/paginate';
 import { UserDocumentsPage } from
-'../../../components/pages/UserDocumentsPage.jsx';
+'../../../components/pages/UserDocumentsPage';
 
 const getUserDocuments = sinon.spy(() => Promise.resolve());
 const nextPageSpy = sinon.spy(nextPage);

--- a/client/tests/components/pages/ViewDocumentPage.spec.js
+++ b/client/tests/components/pages/ViewDocumentPage.spec.js
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 import { ViewDocumentPage } from
-'../../../components/pages/ViewDocumentPage.jsx';
+'../../../components/pages/ViewDocumentPage';
 
 const getDocument = sinon.spy(() => Promise.resolve());
 const deleteDocument = sinon.spy(() => Promise.resolve());

--- a/client/tests/components/protectors/IsAdmin.spec.js
+++ b/client/tests/components/protectors/IsAdmin.spec.js
@@ -1,7 +1,7 @@
 import expect from 'expect';
 import React from 'react';
 import { mount } from 'enzyme';
-import { IsAdmin } from '../../../components/protectors/IsAdmin.jsx';
+import { IsAdmin } from '../../../components/protectors/IsAdmin';
 
 const props = {
   access: { loggedIn: true, user: { roleId: 2 } },

--- a/client/tests/components/protectors/IsSuperAdmin.spec.js
+++ b/client/tests/components/protectors/IsSuperAdmin.spec.js
@@ -1,7 +1,7 @@
 import expect from 'expect';
 import React from 'react';
 import { mount } from 'enzyme';
-import { IsSuperAdmin } from '../../../components/protectors/IsSuperAdmin.jsx';
+import { IsSuperAdmin } from '../../../components/protectors/IsSuperAdmin';
 
 const props = {
   access: { loggedIn: true, user: { roleId: 1 } },

--- a/server/app.js
+++ b/server/app.js
@@ -31,6 +31,11 @@ app.use(webpackHotMiddleware(compiler));
 // Require our routes into the application
 routes(app);
 
+// Setup route for api documentation
+app.get('/api', (req, res) => {
+  res.sendFile(path.join(__dirname, '../lib/client/api/index.html'));
+});
+
 // Setup default route that sends back a welcome message
 app.get('*', (req, res) => {
   res.sendFile(path.join(__dirname, '../client/index.html'));

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -28,7 +28,6 @@ export default {
     new CleanWebpackPlugin(['lib/client']),
     new webpack.optimize.OccurrenceOrderPlugin(),
     new webpack.DefinePlugin(GLOBALS),
-    new webpack.NoEmitOnErrorsPlugin(),
     new ExtractTextPlugin('style.css'),
     new webpack.optimize.DedupePlugin(),
     new webpack.optimize.UglifyJsPlugin({ compress: { warnings: false } })

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -10,7 +10,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 
 export default {
-  devtool: 'cheap-eval-source-map',
+  devtool: 'eval-cheap-module-source-map',
   target: 'web',
   entry: path.join(__dirname, 'client/index'),
   output: {

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -28,6 +28,7 @@ export default {
     new CleanWebpackPlugin(['lib/client']),
     new webpack.optimize.OccurrenceOrderPlugin(),
     new webpack.DefinePlugin(GLOBALS),
+    new webpack.NoEmitOnErrorsPlugin(),
     new ExtractTextPlugin('style.css'),
     new webpack.optimize.DedupePlugin(),
     new webpack.optimize.UglifyJsPlugin({ compress: { warnings: false } })


### PR DESCRIPTION
#### What does this PR do?
The PR permanently fixes the bug on production that causes a redirect when an attempt is made to delete a user, role or document.
#### Description of Task to be completed?
Attempting to delete a role, document or user should not take the user to the landing page while displaying the confirm modal.
#### How should this be manually tested?
Login to the application on Heroku, create a document and attempt to delete the document. Also, delete the user account and see that it doesn't redirect while confirm modal is displayed.
#### Any background context you want to provide?
There was a persistent issue on production that causes a redirect to the landing page or an error to be thrown to the console when an attempt is made to delete document, role or user.
#### What are the relevant pivotal tracker stories?
#147680875